### PR TITLE
spawn without args

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -39,17 +39,32 @@ jobs:
 
       - name: Download and Set Up Headless-Shell
         run: |
-          mkdir -p ./out/latest/headless-shell
-          curl -SL https://storage.googleapis.com/chrome-for-testing-public/133.0.6943.126/linux64/chrome-headless-shell-linux64.zip -o chrome-headless-shell-linux64.zip
-          unzip chrome-headless-shell-linux64.zip -d ./out/latest/headless-shell
-          chmod +x ./out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
-          chmod -R 777 ./out/
+          sudo mkdir -p /out/latest/headless-shell
+          sudo curl -SL https://storage.googleapis.com/chrome-for-testing-public/133.0.6943.126/linux64/chrome-headless-shell-linux64.zip -o chrome-headless-shell-linux64.zip
+          sudo unzip chrome-headless-shell-linux64.zip -d /out/latest/headless-shell
+          sudo chmod +x /out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
+          sudo chmod -R 777 /out
           npx playwright install-deps chromium
 
+      - name: Test Chrome Installation
+        run: |
+          /out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell \
+          --headless \
+          --no-sandbox \
+          --disable-gpu \
+          --dump-dom https://www.example.com \
+          > test_output.txt
+          if grep -q "Example Domain" test_output.txt; then
+            echo "Chrome headless shell is functioning properly."
+          else
+            echo "Failed to run Chrome headless shell." && exit 1
+          fi
+          
       - name: Run Tests
         run: |
-          cargo test --package headless_browser --test cdp
+          cargo test --package headless_browser --test cdp -- --nocapture
         env: 
           HEADLESS: true
-          DEBUG_JSON: true
-          CHROME_PATH: ./out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
+          CHROME_PATH: /out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
+          RUST_LOG: info,error,warn
+          TEST_NO_ARGS: false

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,12 +43,13 @@ jobs:
           curl -SL https://storage.googleapis.com/chrome-for-testing-public/133.0.6943.126/linux64/chrome-headless-shell-linux64.zip -o chrome-headless-shell-linux64.zip
           unzip chrome-headless-shell-linux64.zip -d ./out/latest/headless-shell
           chmod +x ./out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
-          chmod -R 777 ./out/latest/headless-shell/chrome-headless-shell-linux64
+          chmod -R 777 ./out/
           npx playwright install-deps chromium
 
-      # - name: Run Tests
-      #   run: |
-      #     cargo test --package headless_browser --test cdp
-      #   env: 
-      #     HEADLESS: true
-      #     CHROME_PATH: ./out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell
+      - name: Run Tests
+        run: |
+          cargo test --package headless_browser --test cdp
+        env: 
+          HEADLESS: true
+          DEBUG_JSON: true
+          CHROME_PATH: ./out/latest/headless-shell/chrome-headless-shell-linux64/chrome-headless-shell

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,7 +573,7 @@ dependencies = [
 
 [[package]]
 name = "headless_browser"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "futures-util",
  "headless_browser_lib",
@@ -586,7 +586,7 @@ dependencies = [
 
 [[package]]
 name = "headless_browser_lib"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "cached",
  "http-body-util",

--- a/headless_browser/Cargo.toml
+++ b/headless_browser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless_browser"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = [
     "j-mendez <jeff@spider.cloud>"

--- a/headless_browser_lib/Cargo.toml
+++ b/headless_browser_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "headless_browser_lib"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 authors = [
     "j-mendez <jeff@spider.cloud>"


### PR DESCRIPTION
use the env `TEST_NO_ARGS` to spawn chrome without any extra args during tests.

The baseline args improve performance by 30% on the simple test cases for example.com and spider.cloud running both of them concurrently.